### PR TITLE
Improve dashboards and login navigation

### DIFF
--- a/frontend/lib/screens/candidate_dashboard.dart
+++ b/frontend/lib/screens/candidate_dashboard.dart
@@ -7,7 +7,22 @@ class CandidateDashboard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Candidate Dashboard')),
-      body: const Center(child: Text('Candidate features here')), 
+      body: ListView(
+        children: const [
+          ListTile(
+            leading: Icon(Icons.search),
+            title: Text('Search for jobs'),
+          ),
+          ListTile(
+            leading: Icon(Icons.description),
+            title: Text('View your applications'),
+          ),
+          ListTile(
+            leading: Icon(Icons.person),
+            title: Text('Manage your profile'),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/frontend/lib/screens/login.dart
+++ b/frontend/lib/screens/login.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'candidate_dashboard.dart';
+import 'recruiter_dashboard.dart';
 import 'signup.dart';
 
 class LoginScreen extends StatelessWidget {
@@ -13,6 +15,28 @@ class LoginScreen extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => const CandidateDashboard()),
+                );
+              },
+              child: const Text('Login as Candidate'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => const RecruiterDashboard()),
+                );
+              },
+              child: const Text('Login as Recruiter'),
+            ),
+            const SizedBox(height: 16),
+            TextButton(
               onPressed: () {
                 Navigator.push(
                   context,

--- a/frontend/lib/screens/recruiter_dashboard.dart
+++ b/frontend/lib/screens/recruiter_dashboard.dart
@@ -7,7 +7,22 @@ class RecruiterDashboard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Recruiter Dashboard')),
-      body: const Center(child: Text('Recruiter features here')),
+      body: ListView(
+        children: const [
+          ListTile(
+            leading: Icon(Icons.add),
+            title: Text('Post a new job'),
+          ),
+          ListTile(
+            leading: Icon(Icons.work),
+            title: Text('Manage job postings'),
+          ),
+          ListTile(
+            leading: Icon(Icons.people),
+            title: Text('Review applicants'),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- flesh out candidate and recruiter dashboards with actionable items
- route login actions to the correct dashboard

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865482309948324bc093d34f1d44431