### PR TITLE
Add auth provider with Provider package

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,8 +1,16 @@
 import 'package:flutter/material.dart';
 import 'screens/login.dart';
+import 'screens/home.dart';
+import 'package:provider/provider.dart';
+import 'providers/auth_provider.dart';
 
 void main() {
-  runApp(const TalentFlowApp());
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) => AuthProvider(),
+      child: const TalentFlowApp(),
+    ),
+  );
 }
 
 class TalentFlowApp extends StatelessWidget {
@@ -10,10 +18,14 @@ class TalentFlowApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'TalentFlow',
-      theme: ThemeData(primarySwatch: Colors.blue),
-      home: const LoginScreen(),
+    return Consumer<AuthProvider>(
+      builder: (context, auth, _) {
+        return MaterialApp(
+          title: 'TalentFlow',
+          theme: ThemeData(primarySwatch: Colors.blue),
+          home: auth.isLoggedIn ? const HomeScreen() : const LoginScreen(),
+        );
+      },
     );
   }
 }

--- a/frontend/lib/providers/auth_provider.dart
+++ b/frontend/lib/providers/auth_provider.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class AuthProvider extends ChangeNotifier {
+  bool _isLoggedIn = false;
+
+  bool get isLoggedIn => _isLoggedIn;
+
+  void login() {
+    _isLoggedIn = true;
+    notifyListeners();
+  }
+
+  void logout() {
+    _isLoggedIn = false;
+    notifyListeners();
+  }
+}

--- a/frontend/lib/screens/home.dart
+++ b/frontend/lib/screens/home.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/auth_provider.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -7,7 +9,20 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Home')),
-      body: const Center(child: Text('Home Page')), 
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Home Page'),
+            ElevatedButton(
+              onPressed: () {
+                Provider.of<AuthProvider>(context, listen: false).logout();
+              },
+              child: const Text('Logout'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/frontend/lib/screens/login.dart
+++ b/frontend/lib/screens/login.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'signup.dart';
+import 'package:provider/provider.dart';
+import '../providers/auth_provider.dart';
 
 class LoginScreen extends StatelessWidget {
   const LoginScreen({Key? key}) : super(key: key);
@@ -12,6 +14,12 @@ class LoginScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
+            ElevatedButton(
+              onPressed: () {
+                Provider.of<AuthProvider>(context, listen: false).login();
+              },
+              child: const Text('Login'),
+            ),
             ElevatedButton(
               onPressed: () {
                 Navigator.push(

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.13.0
+  provider: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `provider` dependency to Flutter app
- implement `AuthProvider` using `ChangeNotifier`
- update main app to show login or home based on auth state
- add login button to set auth state
- add logout button on home screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654823db988324bdb9cc315a5ca86e