### PR TITLE
Update Dart SDK constraint

### DIFF
--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- bump `frontend` Dart SDK constraint to `>=2.17.0 <4.0.0`
- attempted to run `flutter pub get` but `flutter` wasn't installed

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865482603c883248c2ba9d24a0226c3