### PR TITLE
Add signup template directory

### DIFF
--- a/backend/templates/registration/signup.html
+++ b/backend/templates/registration/signup.html
@@ -1,0 +1,10 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+  <h2>Sign Up</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Sign up</button>
+  </form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add templates/registration folder for auth views
- add basic signup template

## Testing
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6865482e5c1c83248bfc84485d01635a