### PR TITLE
Read settings from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SECRET_KEY=replace-me
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ packages
 
 # Others
 .DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -12,3 +12,15 @@ Ce dépôt contient une ébauche d'application multi-plateforme pour le projet *
 3. Installez Flutter et exécutez `flutter run` depuis le dossier `frontend` pour lancer l'application.
 
 Ces instructions sont indicatives et nécessitent que votre poste dispose de Python, Django et Flutter.
+
+## Configuration des variables d'environnement
+
+Avant de démarrer, copiez le fichier `.env.example` vers `.env` puis renseignez vos valeurs :
+
+```bash
+cp .env.example .env
+# éditez .env puis exportez les variables dans votre shell
+export $(grep -v '^#' .env | xargs)
+```
+
+`SECRET_KEY` doit contenir une clé Django secrète, `DEBUG` peut valoir `True` ou `False`, et `ALLOWED_HOSTS` liste les domaines autorisés séparés par des virgules.

--- a/backend/talentflow/settings.py
+++ b/backend/talentflow/settings.py
@@ -2,9 +2,13 @@ import os
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-SECRET_KEY = 'replace-me'
-DEBUG = True
-ALLOWED_HOSTS = []
+SECRET_KEY = os.environ.get('SECRET_KEY', 'replace-me')
+
+# DEBUG peut être fourni dans l'environnement sous forme de "True", "False", "1" ou "0".
+DEBUG = os.environ.get('DEBUG', 'True').lower() in ['1', 'true', 'yes']
+
+hosts = os.environ.get('ALLOWED_HOSTS', '')
+ALLOWED_HOSTS = [h.strip() for h in hosts.split(',') if h.strip()] if hosts else []
 
 INSTALLED_APPS = [
     'django.contrib.admin',


### PR DESCRIPTION
## Summary
- load `SECRET_KEY`, `DEBUG` and `ALLOWED_HOSTS` from environment variables
- document environment variables in the README
- provide `.env.example`
- ignore user `.env` files

## Testing
- `python backend/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68654831e1608324873c8bcdfbde7b6a