### PR TITLE
Implement signup form and API

### DIFF
--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 from django.contrib.auth import views as auth_views
-from .views import SignUpView
+from .views import SignUpView, signup_api
 
 urlpatterns = [
     path('login/', auth_views.LoginView.as_view(), name='login'),
     path('logout/', auth_views.LogoutView.as_view(), name='logout'),
     path('signup/', SignUpView.as_view(), name='signup'),
+    path('api/signup/', signup_api, name='api_signup'),
 ]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,9 +1,41 @@
 from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
+from django.http import JsonResponse
 from django.urls import reverse_lazy
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.edit import CreateView
+import json
+
+from .models import CandidateProfile
 
 
 class SignUpView(CreateView):
     form_class = UserCreationForm
     success_url = reverse_lazy('login')
     template_name = 'registration/signup.html'
+
+
+@csrf_exempt
+def signup_api(request):
+    """Simple API endpoint to create a user and optional candidate profile."""
+    if request.method != 'POST':
+        return JsonResponse({'error': 'Only POST allowed'}, status=405)
+
+    try:
+        payload = json.loads(request.body.decode())
+    except (json.JSONDecodeError, AttributeError):
+        payload = request.POST
+
+    username = payload.get('username')
+    password = payload.get('password')
+    bio = payload.get('bio', '')
+
+    if not username or not password:
+        return JsonResponse({'error': 'username and password required'}, status=400)
+
+    if User.objects.filter(username=username).exists():
+        return JsonResponse({'error': 'user already exists'}, status=400)
+
+    user = User.objects.create_user(username=username, password=password)
+    CandidateProfile.objects.create(user=user, bio=bio)
+    return JsonResponse({'status': 'ok'})

--- a/frontend/lib/screens/signup.dart
+++ b/frontend/lib/screens/signup.dart
@@ -1,14 +1,114 @@
-import 'package:flutter/material.dart';
+import 'dart:convert';
 
-class SignupScreen extends StatelessWidget {
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+class SignupScreen extends StatefulWidget {
   const SignupScreen({Key? key}) : super(key: key);
+
+  @override
+  State<SignupScreen> createState() => _SignupScreenState();
+}
+
+class _SignupScreenState extends State<SignupScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _bioController = TextEditingController();
+
+  String? _message;
+  bool _submitting = false;
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() {
+      _submitting = true;
+      _message = null;
+    });
+
+    final response = await http.post(
+      Uri.parse('http://localhost:8000/accounts/api/signup/'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'username': _usernameController.text,
+        'password': _passwordController.text,
+        'bio': _bioController.text,
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      setState(() {
+        _message = 'Signup successful';
+      });
+    } else {
+      String error = 'Signup failed';
+      try {
+        final decoded = jsonDecode(response.body);
+        if (decoded['error'] != null) {
+          error = decoded['error'];
+        }
+      } catch (_) {}
+      setState(() {
+        _message = error;
+      });
+    }
+
+    setState(() {
+      _submitting = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _passwordController.dispose();
+    _bioController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Signup')),
-      body: const Center(
-        child: Text('Signup Form Placeholder'),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TextFormField(
+                controller: _usernameController,
+                decoration: const InputDecoration(labelText: 'Username'),
+                validator: (v) => v == null || v.isEmpty ? 'Enter username' : null,
+              ),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+                validator: (v) => v == null || v.isEmpty ? 'Enter password' : null,
+              ),
+              TextFormField(
+                controller: _bioController,
+                decoration: const InputDecoration(labelText: 'Profile Info (optional)'),
+              ),
+              const SizedBox(height: 20),
+              if (_message != null)
+                Text(
+                  _message!,
+                  style: TextStyle(
+                    color: _message == 'Signup successful' ? Colors.green : Colors.red,
+                  ),
+                ),
+              const SizedBox(height: 10),
+              ElevatedButton(
+                onPressed: _submitting ? null : _submit,
+                child: Text(_submitting ? 'Submitting...' : 'Signup'),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add new signup API on the backend
- expose api/signup route
- implement signup form on Flutter with POST request

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654821fc588324a31fe87b593e3b5a